### PR TITLE
feat: add LLM responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ BOT_TOKEN=add_your_bot_token_here
 
 # Optional: Bot name for logging
 BOT_NAME=BamboolinoBot
+
+# API_KEY that Danila posted in the feedback of the project description submission   
+LLM_API_KEY=add_your_api_key_here

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
+# SETUP PROCESS:
+# add your BOT_TOKEN, BOT_NAME and LLM_API_KEY into .env
+# python -m venv .venv
+# .venv\Scripts\activate
+# pip install -r requirements.txt
+
 # Core bot dependencies
 aiogram==3.20.0
 python-dotenv==1.0.0
@@ -6,21 +12,27 @@ python-dotenv==1.0.0
 # openai==1.3.8
 # openai-whisper==20231117
 git+https://github.com/openai/whisper.git
+tiktoken==0.9.0
+torch==2.7.1
+numba==0.61.2
+llvmlite==0.44.0
 
 # Audio processing
 pydub==0.25.1
 
 # Image processing and QR codes
 qrcode[pil]==7.4.2
-Pillow==10.1.0
+Pillow==11.0.0
 
 # Web requests and utilities
 requests==2.31.0
-aiohttp==3.9.1
+aiohttp==3.11.18
+httpx==0.27.0
 
 # Data processing
-pandas==2.1.4
-numpy==1.24.3
+pandas==2.3.0
+numpy==2.2.0
 
 # Logging and development
 colorlog==6.8.0
+more-itertools==10.7.0

--- a/utils/llm_connector.py
+++ b/utils/llm_connector.py
@@ -1,0 +1,74 @@
+import httpx
+import asyncio
+import os
+
+from features.qa_system.qa_data import QA_DATABASE
+
+API_URL = "http://134.60.124.44:8000"
+API_KEY = os.getenv("LLM_API_KEY")
+USER_ID = "group4"
+
+def build_system_prompt(language: str = "en") -> str:
+    if language == "de":
+        prompt_lines = [
+            "Du bist ein hilfreicher Assistent für den Bamboolino Indoor-Spielplatz.",
+            "Beantworte Benutzerfragen ausschließlich basierend auf den folgenden Fakten.",
+            "Wenn du etwas nicht weißt, sag einfach, dass du es nicht weißt.\n"
+        ]
+    else:
+        prompt_lines = [
+            "You are a helpful assistant for the Bamboolino indoor playground.",
+            "Answer user questions only using the following facts.",
+            "If you don't know something, just say you don't know.\n"
+        ]
+    
+    for key, data in QA_DATABASE.items():
+        if language in data:
+            section_title = key.replace("_", " ").title()
+            prompt_lines.append(f"{section_title}:\n{data[language]}")
+    
+    return "\n\n".join(prompt_lines)
+
+async def query_llm(user_input: str, language: str = "en", max_tokens: int = 64) -> str:
+    history = [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": build_system_prompt(language)}]
+        },
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": user_input}]
+        }
+    ]
+
+    payload = {
+        "user_id": USER_ID,
+        "messages": history,
+        "max_new_tokens": max_tokens
+    }
+
+    headers = {
+        "Authorization": API_KEY,
+        "Content-Type": "application/json"
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.post(f"{API_URL}/tasks", json=payload, headers=headers)
+            resp.raise_for_status()
+            task_id = resp.json()["task_id"]
+        except Exception as e:
+            return f"❌ Fehler beim Senden: {e}"
+
+        while True:
+            try:
+                result = await client.get(f"{API_URL}/tasks/{task_id}/response")
+                result.raise_for_status()
+                data = result.json()
+                messages = data.get("response")
+
+                if messages:
+                    return messages[-1]["content"][0]["text"]
+                await asyncio.sleep(2)
+            except Exception as e:
+                return f"❌ Fehler beim Empfangen: {e}"


### PR DESCRIPTION
.env.example:
- added the API_KEY that was posted in the feedback of the project description submission

main.py:
- added a function to handle Markdown parsing errors (the LLM answers are Markdown, that Telegram can't always display)
- added LLM answers for text messages
- added LLM answers for process_transcribed_text (voice messages)

requirements.txt:
- added comments for the setup process
- changed some imports due to complications for my os (Win10)

llm_connector.py:
- added the google/gemma-3-1b-it LLM
- added a context history specifically for our Digital Assistant